### PR TITLE
Fix streamdiffusion install

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,6 +8,6 @@ dependencies = [
     "torchvision>=0.16.0",
     "xformers",
     "huggingface-hub>=0.25.0",
-    "diffusers>=0.32.2",
-    "protobuf==5.27.2"
+    "diffusers>=0.31.0",
+    "protobuf>=4.25.3"
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,10 +4,10 @@ build-backend = "setuptools.build_meta"
 
 [project]
 dependencies = [
-    "torch==2.1.0",
-    "torchvision==0.16.0",
+    "torch>=2.3.0",
+    "torchvision>=0.16.0",
     "xformers",
-    "huggingface-hub==0.23.2",
-    "diffusers==0.30.0",
+    "huggingface-hub>=0.25.0",
+    "diffusers>=0.32.2",
     "protobuf==5.27.2"
 ]

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,6 +2,6 @@ torch>=2.3.0
 torchvision>=0.16.0
 xformers
 huggingface-hub>=0.25.0
-diffusers>=0.32.2
-protobuf>=5.27.2
-git+https://github.com/eliteprox/StreamDiffusion.git@main#egg=streamdiffusion[tensorrt]
+diffusers>=0.31.0
+protobuf>=4.25.3
+streamdiffusion[tensorrt] @ git+https://github.com/eliteprox/StreamDiffusion.git@test-diffusers

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,4 +4,4 @@ xformers
 huggingface-hub>=0.25.0
 diffusers>=0.31.0
 protobuf>=4.25.3
-streamdiffusion[tensorrt] @ git+https://github.com/eliteprox/StreamDiffusion.git@main
+streamdiffusion[tensorrt] @ git+https://github.com/pschroedl/StreamDiffusion.git@main

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,6 +2,6 @@ torch>=2.3.0
 torchvision>=0.16.0
 xformers
 huggingface-hub>=0.25.0
-diffusers>=0.32.1
+diffusers>=0.32.2
 protobuf>=5.27.2
 git+https://github.com/eliteprox/StreamDiffusion.git@main#egg=streamdiffusion[tensorrt]

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,4 +4,4 @@ xformers
 huggingface-hub>=0.25.0
 diffusers>=0.31.0
 protobuf>=4.25.3
-streamdiffusion[tensorrt] @ git+https://github.com/eliteprox/StreamDiffusion.git@test-diffusers
+streamdiffusion[tensorrt] @ git+https://github.com/eliteprox/StreamDiffusion.git@main

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
 torch>=2.3.0
 torchvision>=0.16.0
 xformers
-huggingface-hub==0.23.2
-diffusers==0.30.0
-protobuf==3.20.2
-git+https://github.com/pschroedl/StreamDiffusion.git@ab5c9c1#egg=streamdiffusion[tensorrt]
+huggingface-hub>=0.25.0
+diffusers>=0.32.1
+protobuf>=5.27.2
+git+https://github.com/eliteprox/StreamDiffusion.git@main#egg=streamdiffusion[tensorrt]

--- a/setup.py
+++ b/setup.py
@@ -5,12 +5,12 @@ setup(
     version="0.1.0",
     description="StreamDiffusion project dependencies",
     install_requires=[
-        "torch==2.1.0",
-        "torchvision==0.16.0",
+        "torch>=2.3.0",
+        "torchvision>=0.16.0",
         "xformers",
-        "huggingface-hub==0.23.2",
-        "diffusers==0.30.0",
-        "protobuf==5.27.2"
+        "huggingface-hub>=0.25.0",
+        "diffusers>=0.32.2",
+        "protobuf=>5.27.2"
     ],
     python_requires=">=3.10",
 )

--- a/setup.py
+++ b/setup.py
@@ -9,8 +9,8 @@ setup(
         "torchvision>=0.16.0",
         "xformers",
         "huggingface-hub>=0.25.0",
-        "diffusers>=0.32.2",
-        "protobuf=>5.27.2"
+        "diffusers>=0.31.0",
+        "protobuf=>4.25.3",
     ],
     python_requires=">=3.10",
 )

--- a/setup.py
+++ b/setup.py
@@ -10,7 +10,7 @@ setup(
         "xformers",
         "huggingface-hub>=0.25.0",
         "diffusers>=0.31.0",
-        "protobuf=>4.25.3",
+        "protobuf>=4.25.3",
     ],
     python_requires=">=3.10",
 )


### PR DESCRIPTION
Fixes inconsistency with torch and upgrades protobuf requirement, now set to `torch>=2.3.0` and `protobuf>=5.27.2`
Fixes inconsistency with diffusers and upgrades requirement to `diffusers>=0.31.0`
Fixes huggingface-hub conflict by using `huggingface-hub>=0.25.0`
